### PR TITLE
Fix Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ RUN apk --no-cache update && \
     apk --no-cache upgrade && \
     apk add build-base git
 
+RUN go get -u github.com/golang/dep/cmd/dep
+
 RUN  dos2unix build.sh && ./build.sh
 
 CMD ["./dist/tide-whisperer"]


### PR DESCRIPTION
Docker build was missing the Golang dependencies package (_dep_) to finish properly.